### PR TITLE
BUG FIX: Package fails to install with _R_CHECK_LENGTH_1_CONDITION_=true

### DIFF
--- a/configure
+++ b/configure
@@ -1710,7 +1710,7 @@ fi
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking R package BH " >&5
 $as_echo_n "checking R package BH ... " >&6; }
 
-    TEST=$( $R --silent --vanilla -e 'if(is.na(packageDescription("BH"))) stop("not found")' 2>/dev/null )
+    TEST=$( $R --silent --vanilla -e 'if(system.file(package="BH") == "") stop("not found")' 2>/dev/null )
     if test $? -eq 0; then :
 
 else
@@ -1740,7 +1740,7 @@ $as_echo "yes" >&6; }
 
 
 
-BOOSTLOC=`${R} --slave -e 'cat(paste0(system.file(package="BH"),"/include"))'`
+BOOSTLOC=`${R} --slave -e 'cat(system.file(package="BH", "include")))'`
 
 # If R_HOME was hidden, restore it
 if test -n "${FAKE_R_HOME}";

--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,7 @@ fi
 
 # Check for package
 AX_R_PACKAGE([BH],,[${R}])
-BOOSTLOC=`${R} --slave -e 'cat(paste0(system.file(package="BH"),"/include"))'`
+BOOSTLOC=`${R} --slave -e 'cat(system.file(package="BH", "include")))'`
 
 # If R_HOME was hidden, restore it
 if test -n "${FAKE_R_HOME}";

--- a/m4/ax_r_package.m4
+++ b/m4/ax_r_package.m4
@@ -40,7 +40,7 @@ AC_DEFUN([AX_R_PACKAGE], [
 
     AC_MSG_CHECKING([R package PKG VERSION])
 
-    TEST=$( $R --silent --vanilla -e 'if(is.na(packageDescription("PKG"))) stop("not found")' 2>/dev/null )
+    TEST=$( $R --silent --vanilla -e 'if(system.file(package="PKG") == "") stop("not found")' 2>/dev/null )
     AS_IF([test $? -eq 0], [], [
       AC_MSG_RESULT([no])
       AC_MSG_ERROR([R package PKG not found.])


### PR DESCRIPTION
With `_R_CHECK_LENGTH_1_CONDITION_=true` set, the package fails to install;

```
* installing to library ‘/home/hb/R/x86_64-pc-linux-gnu-library/3.6-custom’
* installing *source* package ‘RBGL’ ...
** using staged installation
checking R package BH ... no
configure: error: R package BH not found.
ERROR: configuration failed for package ‘RBGL’
```

The reason for this is because:

```
$ _R_CHECK_LENGTH_1_CONDITION_=true R --silent --vanilla -e 'if(is.na(packageDescription("BH"))) stop("not found")'
> if(is.na(packageDescription("BH"))) stop("not found")
Error in if (is.na(packageDescription("BH"))) stop("not found") : 
  the condition has length > 1
Execution halted
```
