### PR TITLE
Make code analyzable by rchk

### DIFF
--- a/src/incrConnComp.cpp
+++ b/src/incrConnComp.cpp
@@ -60,10 +60,11 @@ extern "C"
 
         SEXP anslst, conn, outvec;
         PROTECT(anslst = Rf_allocVector(VECSXP,NC+1));
+	
 	PROTECT(conn = Rf_allocVector(INTSXP, 1));
-
 	INTEGER(conn)[0] = NC;
 	SET_VECTOR_ELT(anslst,0,conn);
+	UNPROTECT(1);
 
 	int l;
 
@@ -80,10 +81,11 @@ extern "C"
                 INTEGER(outvec)[l++] =(int) child_index;
             }
 	    SET_VECTOR_ELT(anslst,k+1,outvec);   // use offset into anslst, top element is NC
+            UNPROTECT(1);
             k = k+1;  // was l+1 seems to be bug
         }
 
-        UNPROTECT(NC+2);
+        UNPROTECT(1);
         return(anslst);
     }
     SEXP BGL_init_incremental_components(SEXP num_verts_in,

--- a/src/planar.cpp
+++ b/src/planar.cpp
@@ -166,9 +166,10 @@ extern "C"
                     INTEGER(ans)[j] = v_vis.f_vis[i][j];
 
                 SET_VECTOR_ELT(ansList,i, ans);
+                UNPROTECT(1);
            }
 
-           UNPROTECT(1+v_vis.f_vis.size());
+           UNPROTECT(1);
            return ansList;
   	}
   	else


### PR DESCRIPTION
I wanted to analyze this package with rchk but it failed with the following error:

>  [UP] protect stack is too deep, unprotecting all variables, results will be incomplete
>  [PB] has too high protection stack depth results will be incomplete

This can be resolved by `UNPROTECT()`ing the variables in each step of the loop rather than at the end of the loop.

After this change, the code can be analyzed by rchk, which reports no errors.

This change has no functional effects so feel free to ignore it and close this PR. It might make the code slightly more readable and easier to maintain (since it can now be analyzed by rchk). If on the other hand, you'd rather not take the risk to break something that is not broken, I also understand.